### PR TITLE
feature/WDP191000-7-Select-In-Menu

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -258,21 +258,25 @@ header {
         align-items: center;
         position: relative;
 
-        input {
+        input,
+        input:focus {
           border: 0;
           padding-left: 10px;
           font-size: 14px;
           outline: none;
+          -moz-outline: none;
 
           &::placeholder {
             color: $gen-black;
           }
         }
 
-        button {
+        button,
+        button:focus {
           border: 0;
           background-color: transparent;
           outline: none;
+          -moz-outline: none;
         }
       }
     }


### PR DESCRIPTION
Issue: Select button style was not proper as well as no hover effect presented.
Solution: As I checked on "can i use" outline: none is working for all main browsers, however I was instructed  to make changes for firefox browser. I added such prefix into input line not into <select> because I changed it into list in previous task. 
Hover effect was also changed with previous task WDP191000-10.