### PR TITLE
Feature/WDP191000-28-rwd-gallery-section

### DIFF
--- a/src/partials/60_section-gallery.html
+++ b/src/partials/60_section-gallery.html
@@ -1,7 +1,7 @@
 <div class="section--gallery">
   <div class="container">
     <div class="row">
-      <div class="col-6">
+      <div class="col-12 col-md-6">
         <div class="panel-bar">
           <div class="row no-gutters align-items-end">
             <div class="col heading"><h3>Furniture Gallery</h3></div>

--- a/src/sass/components/_section--gallery.scss
+++ b/src/sass/components/_section--gallery.scss
@@ -7,6 +7,9 @@
       font-weight: 500;
       .nav-tabs {
         .nav-item {
+          width: 25%;
+          text-align: center;
+
           .nav-link {
             color: $gen-black;
             border-bottom: 0;
@@ -164,6 +167,7 @@
             .gallery-overlay {
               background-color: $gallery-background-color;
               opacity: 0.5;
+              cursor: pointer;
             }
 
             img {
@@ -213,6 +217,34 @@
         background-color: $gallery-color-green;
         border-radius: 5px;
         padding: 10px 13px;
+      }
+    }
+  }
+}
+
+@media (max-width: $screen-md) {
+  .featured-product {
+    display: none;
+  }
+}
+
+@media (min-width: $screen-md) and (max-width: $screen-xl) {
+  .section--gallery {
+    .gallery-container {
+      .tabs-product {
+        .nav-tabs {
+          .nav-item {
+            width: 50%;
+          }
+        }
+      }
+
+      .tab-pane {
+        .selected-product {
+          img {
+            width: 100%;
+          }
+        }
       }
     }
   }

--- a/src/sass/components/_section--gallery.scss
+++ b/src/sass/components/_section--gallery.scss
@@ -13,6 +13,7 @@
           .nav-link {
             color: $gen-black;
             border-bottom: 0;
+            padding: 0.6rem 0;
 
             &:hover {
               color: $primary;
@@ -222,30 +223,28 @@
   }
 }
 
+@media (max-width: $screen-sm) {
+  .nav-link {
+    font-size: 11px;
+  }
+
+  .selected-product {
+    height: 300px !important;
+  }
+}
+
 @media (max-width: $screen-md) {
   .featured-product {
     display: none;
   }
 }
 
-@media (min-width: $screen-md) and (max-width: $screen-xl) {
-  .section--gallery {
-    .gallery-container {
-      .tabs-product {
-        .nav-tabs {
-          .nav-item {
-            width: 50%;
-          }
-        }
-      }
+@media (min-width: $screen-md) and (max-width: $screen-lg) {
+  .nav-link {
+    font-size: 13px;
+  }
 
-      .tab-pane {
-        .selected-product {
-          img {
-            width: 100%;
-          }
-        }
-      }
-    }
+  .selected-product {
+    height: 300px !important;
   }
 }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -54,8 +54,22 @@ function initializeGalleryTab (galleryTab) {
     mouseDrag: true,
     controls: false,
     nav: false,
-    items: 6,
-    slideBy: 'page'
+    items: 3,
+    slideBy: 'page',
+    responsive: {
+      576: {
+        items: 6
+      },
+      768: {
+        items: 3
+      },
+      992: {
+        items: 6
+      },
+      1200: {
+        items: 6
+      }
+    }
   });
 
   const galleryNextArrows = document.querySelectorAll(


### PR DESCRIPTION
For mobile devices the ` .featured-product` is hidden. 
Depending on the screen size we display either 3 or 6 thumbnails.

Mobile:
![Screenshot from 2019-11-16 18-32-20](https://user-images.githubusercontent.com/52067952/68996978-75f57980-08a1-11ea-9d88-89778dcf34df.png)

Big mobile:
![Screenshot from 2019-11-16 18-31-47](https://user-images.githubusercontent.com/52067952/68996981-7ee64b00-08a1-11ea-96fa-65051aba7cfb.png)

Desktop:
![Screenshot from 2019-11-14 22-21-45](https://user-images.githubusercontent.com/52067952/68897739-63a6fe80-072e-11ea-935e-962d14f471ee.png)
